### PR TITLE
Manual acknowledgment and reactive consumption for the requests

### DIFF
--- a/cse-adapter-app/src/main/resources/application.yml
+++ b/cse-adapter-app/src/main/resources/application.yml
@@ -10,6 +10,11 @@ spring:
         handleRun-in-0:
           binder: rabbit
           destination: cse-idcc-launch-task
+      rabbit:
+        bindings:
+          handleRun-in-0:
+            consumer:
+              acknowledge-mode: MANUAL
 
 cse-cc-runner:
   binding:

--- a/cse-adapter-app/src/test/java/com/farao_community/farao/cse/adapter/app/CseAdapterListenerTest.java
+++ b/cse-adapter-app/src/test/java/com/farao_community/farao/cse/adapter/app/CseAdapterListenerTest.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -83,7 +82,7 @@ class CseAdapterListenerTest {
         TaskDto idccTaskDto = getIdccTaskDto();
         CseRequest idccCseRequest = Mockito.mock(CseRequest.class);
         Mockito.when(cseAdapterListener.getIdccRequest(idccTaskDto)).thenReturn(idccCseRequest);
-        cseAdapterListener.handleRun().accept(idccTaskDto);
+        cseAdapterListener.runRequestFromTaskDto(idccTaskDto);
         assertDoesNotThrow((ThrowingSupplier<RuntimeException>) RuntimeException::new);
     }
 
@@ -93,7 +92,7 @@ class CseAdapterListenerTest {
         TaskDto d2ccTaskDto = getD2ccTaskDto();
         CseRequest d2ccCseRequest = Mockito.mock(CseRequest.class);
         Mockito.when(cseAdapterListener.getD2ccRequest(d2ccTaskDto)).thenReturn(d2ccCseRequest);
-        cseAdapterListener.handleRun().accept(d2ccTaskDto);
+        cseAdapterListener.runRequestFromTaskDto(d2ccTaskDto);
         assertDoesNotThrow((ThrowingSupplier<RuntimeException>) RuntimeException::new);
     }
 
@@ -102,8 +101,7 @@ class CseAdapterListenerTest {
         when(cseAdapterConfiguration.getTargetProcess()).thenReturn("INVALID");
         TaskDto d2ccTaskDto = getD2ccTaskDto();
 
-        Consumer<TaskDto> handleRun = cseAdapterListener.handleRun();
-        assertThrows(NotImplementedException.class, () -> handleRun.accept(d2ccTaskDto));
+        assertThrows(NotImplementedException.class, () -> cseAdapterListener.runRequestFromTaskDto(d2ccTaskDto));
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Ack of the request message was not done within the timeout limit of RabbitMQ. Then RabbitMQ was requeuing the message and computation on one timestamp was done several times. To fix that we now perform a manual ack of the message at the beginning of message consuming to be sure we don't reach timeout.
